### PR TITLE
node 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 
 node_js:
-  - "0.11"
-  - "0.10"
-
+  - "8"
+  - "9"

--- a/README.md
+++ b/README.md
@@ -33,34 +33,3 @@ exports.doWork = function () {
     console.log(caller());  // `/path/to/foo.js`
 };
 ```
-
-### Depth
-
-Caller also accepts a `depth` argument for tracing back further (defaults to `1`).
-
-```javascript
-// foo.js
-
-var bar = require('bar');
-bar.doWork();
-```
-
-```javascript
-// bar.js
-
-var baz = require('baz');
-
-exports.doWork = function () {
-    baz.doWork();
-};
-```
-
-```javascript
-// baz.js
-
-var caller = require('caller');
-
-exports.doWork = function () {
-    console.log(caller(2));  // `/path/to/foo.js`
-};
-```

--- a/index.js
+++ b/index.js
@@ -11,19 +11,24 @@ module.exports = function (depth) {
     var pst, stack, file, frame;
 
     pst = Error.prepareStackTrace;
-    Error.prepareStackTrace = function (_, stack) {
+    Error.prepareStackTrace = function (e, frames) {
+        var stack = frames.map((frame) => {
+            return frame.getFileName();
+        });
         Error.prepareStackTrace = pst;
         return stack;
     };
 
     stack = (new Error()).stack;
-    depth = !depth || isNaN(depth) ? 1 : (depth > stack.length - 2 ? stack.length - 2 : depth);
-    stack = stack.slice(depth + 1);
+
+
+    // depth = !depth || isNaN(depth) ? 1 : (depth > stack.length - 5 ? stack.length - 5 : depth);
+    // stack = stack.slice(depth + 1);
+    stack = stack.slice(2);
 
     do {
-        frame = stack.shift();
-        file = frame && frame.getFileName();
-    } while (stack.length && file === 'module.js');
+        file = stack.shift();
+    } while (stack.length && file.match(/module\.js?/));
 
     return file;
 };

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "caller",
   "version": "1.0.1",
   "description": "@substack's caller.js as a module",
+  "engines": {
+   "node": ">=8"
+  },
   "main": "index.js",
   "files": [
     "index.js"

--- a/test/caller.js
+++ b/test/caller.js
@@ -27,27 +27,27 @@ test('caller', function (t) {
         t.end();
     });
 
-    t.test('determine caller with depth', function (t) {
-        var callee, actual, expected;
-
-        callee = require('./fixtures/callee');
-        actual = callee(caller.bind(null, 2));
-        expected = require.resolve('tape/lib/test');
-
-        t.equal(actual, expected);
-        t.end();
-    });
-
-    t.test('determine caller with depth cap', function (t) {
-        var callee, actual, expected;
-
-        callee = require('./fixtures/callee');
-        actual = callee(caller.bind(null, 99));
-        expected = require.resolve('tape/lib/test');
-
-        t.equal(actual, expected);
-        t.end();
-    });
+    // t.test('determine caller with depth', function (t) {
+    //     var callee, actual, expected;
+    //
+    //     callee = require('./fixtures/callee');
+    //     actual = callee(caller.bind(null, 2));
+    //     expected = require.resolve('tape/lib/test');
+    //
+    //     t.equal(actual, expected);
+    //     t.end();
+    // });
+    //
+    // t.test('determine caller with depth cap', function (t) {
+    //     var callee, actual, expected;
+    //
+    //     callee = require('./fixtures/callee');
+    //     actual = callee(caller.bind(null, 99));
+    //     expected = require.resolve('tape/lib/test');
+    //
+    //     t.equal(actual, expected);
+    //     t.end();
+    // });
 
     t.test('determine caller at initialization time', function (t) {
         var actual, expected;


### PR DESCRIPTION

Node 8 has a breaking change in the way the error stack works.

This change addresses that.

Caveat: drops support for `depth`.

Note: this is a breaking change!